### PR TITLE
Remove use of ioutil package

### DIFF
--- a/cmd/makex/makex_cmd.go
+++ b/cmd/makex/makex_cmd.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -37,7 +36,7 @@ The options are:
 	makex.Flags(nil, &conf, "")
 	flag.Parse()
 
-	data, err := ioutil.ReadFile(*file)
+	data, err := os.ReadFile(*file)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/external.go
+++ b/external.go
@@ -1,7 +1,6 @@
 package makex
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 )
@@ -9,13 +8,13 @@ import (
 // External runs makefile using the system `make` tool, optionally passing extra
 // args.
 func External(dir string, makefile []byte, args []string) ([]byte, error) {
-	tmpFile, err := ioutil.TempFile("", "sg-makefile")
+	tmpFile, err := os.CreateTemp("", "sg-makefile")
 	if err != nil {
 		return nil, err
 	}
 	defer os.Remove(tmpFile.Name())
 
-	err = ioutil.WriteFile(tmpFile.Name(), makefile, 0600)
+	err = os.WriteFile(tmpFile.Name(), makefile, 0600)
 	if err != nil {
 		return nil, err
 	}

--- a/make_test.go
+++ b/make_test.go
@@ -2,7 +2,6 @@ package makex
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -19,14 +18,14 @@ func TestMaker_DryRun(t *testing.T) {
 		Rules: []Rule{&BasicRule{TargetFile: "x"}},
 	}
 	mk := conf.NewMaker(mf, "x")
-	err := mk.DryRun(ioutil.Discard)
+	err := mk.DryRun(io.Discard)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestMaker_Run(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "makex")
+	tmpDir, err := os.MkdirTemp("", "makex")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,7 +154,7 @@ func TestTargetsNeedingBuild(t *testing.T) {
 		wantTargetSetsNeedingBuild [][]string
 	}{
 		"do nothing if empty": {
-			mf: &Makefile{},
+			mf:                         &Makefile{},
 			wantTargetSetsNeedingBuild: [][]string{},
 		},
 		"return error if target isn't defined in Makefile": {
@@ -164,15 +163,15 @@ func TestTargetsNeedingBuild(t *testing.T) {
 			wantErr: errNoRuleToMakeTarget("x"),
 		},
 		"don't build target that already exists": {
-			mf:    &Makefile{Rules: []Rule{&BasicRule{TargetFile: "x"}}},
-			fs:    NewFileSystem(rwvfs.Map(map[string]string{"x": ""})),
-			goals: []string{"x"},
+			mf:                         &Makefile{Rules: []Rule{&BasicRule{TargetFile: "x"}}},
+			fs:                         NewFileSystem(rwvfs.Map(map[string]string{"x": ""})),
+			goals:                      []string{"x"},
 			wantTargetSetsNeedingBuild: [][]string{},
 		},
 		"build target that doesn't exist": {
-			mf:    &Makefile{Rules: []Rule{&BasicRule{TargetFile: "x"}}},
-			fs:    NewFileSystem(rwvfs.Map(map[string]string{})),
-			goals: []string{"x"},
+			mf:                         &Makefile{Rules: []Rule{&BasicRule{TargetFile: "x"}}},
+			fs:                         NewFileSystem(rwvfs.Map(map[string]string{})),
+			goals:                      []string{"x"},
 			wantTargetSetsNeedingBuild: [][]string{{"x"}},
 		},
 		"build only target with stale prereq": {
@@ -194,7 +193,7 @@ func TestTargetsNeedingBuild(t *testing.T) {
 				}
 				return nil
 			},
-			goals: []string{"x", "y"},
+			goals:                      []string{"x", "y"},
 			wantTargetSetsNeedingBuild: [][]string{{"x"}},
 		},
 		"build targets recursively that don't exist": {
@@ -202,8 +201,8 @@ func TestTargetsNeedingBuild(t *testing.T) {
 				&BasicRule{TargetFile: "x0", PrereqFiles: []string{"x1"}},
 				&BasicRule{TargetFile: "x1"},
 			}},
-			fs:    NewFileSystem(rwvfs.Map(map[string]string{})),
-			goals: []string{"x0"},
+			fs:                         NewFileSystem(rwvfs.Map(map[string]string{})),
+			goals:                      []string{"x0"},
 			wantTargetSetsNeedingBuild: [][]string{{"x1"}, {"x0"}},
 		},
 
@@ -212,8 +211,8 @@ func TestTargetsNeedingBuild(t *testing.T) {
 				&BasicRule{TargetFile: "x0"},
 				&BasicRule{TargetFile: "x1"},
 			}},
-			fs:    NewFileSystem(rwvfs.Map(map[string]string{})),
-			goals: []string{"x0"},
+			fs:                         NewFileSystem(rwvfs.Map(map[string]string{})),
+			goals:                      []string{"x0"},
 			wantTargetSetsNeedingBuild: [][]string{{"x0"}},
 		},
 		"don't build targets that don't achieve goals (complex)": {
@@ -222,8 +221,8 @@ func TestTargetsNeedingBuild(t *testing.T) {
 				&BasicRule{TargetFile: "x1"},
 				&BasicRule{TargetFile: "y"},
 			}},
-			fs:    NewFileSystem(rwvfs.Map(map[string]string{})),
-			goals: []string{"x0"},
+			fs:                         NewFileSystem(rwvfs.Map(map[string]string{})),
+			goals:                      []string{"x0"},
 			wantTargetSetsNeedingBuild: [][]string{{"y"}, {"x0"}},
 		},
 		"don't build targets that don't achieve goals (even when a common prereq is satisfied)": {
@@ -232,8 +231,8 @@ func TestTargetsNeedingBuild(t *testing.T) {
 				&BasicRule{TargetFile: "x1", PrereqFiles: []string{"y"}},
 				&BasicRule{TargetFile: "y"},
 			}},
-			fs:    NewFileSystem(rwvfs.Map(map[string]string{})),
-			goals: []string{"x0"},
+			fs:                         NewFileSystem(rwvfs.Map(map[string]string{})),
+			goals:                      []string{"x0"},
 			wantTargetSetsNeedingBuild: [][]string{{"y"}, {"x0"}},
 		},
 
@@ -241,8 +240,8 @@ func TestTargetsNeedingBuild(t *testing.T) {
 			mf: &Makefile{Rules: []Rule{
 				&BasicRule{TargetFile: "x0"},
 			}},
-			fs:    NewFileSystem(rwvfs.Map(map[string]string{})),
-			goals: []string{"x0", "x0"},
+			fs:                         NewFileSystem(rwvfs.Map(map[string]string{})),
+			goals:                      []string{"x0", "x0"},
 			wantTargetSetsNeedingBuild: [][]string{{"x0"}},
 		},
 		"don't build any targets more than once": {
@@ -251,8 +250,8 @@ func TestTargetsNeedingBuild(t *testing.T) {
 				&BasicRule{TargetFile: "x1", PrereqFiles: []string{"y"}},
 				&BasicRule{TargetFile: "y"},
 			}},
-			fs:    NewFileSystem(rwvfs.Map(map[string]string{})),
-			goals: []string{"x0", "x1"},
+			fs:                         NewFileSystem(rwvfs.Map(map[string]string{})),
+			goals:                      []string{"x0", "x1"},
 			wantTargetSetsNeedingBuild: [][]string{{"y"}, {"x0", "x1"}},
 		},
 		"detect 1-cycles": {
@@ -280,7 +279,7 @@ func TestTargetsNeedingBuild(t *testing.T) {
 			fs: newModTimeFileSystem(rwvfs.Map(map[string]string{
 				"all": "", "file": "",
 			})),
-			goals: []string{"all"},
+			goals:                      []string{"all"},
 			wantTargetSetsNeedingBuild: [][]string{{"all"}},
 		},
 		"re-build .PHONY pre-requisite": {
@@ -292,7 +291,7 @@ func TestTargetsNeedingBuild(t *testing.T) {
 			fs: newModTimeFileSystem(rwvfs.Map(map[string]string{
 				"all": "", "compile": "", "file": "",
 			})),
-			goals: []string{"all"},
+			goals:                      []string{"all"},
 			wantTargetSetsNeedingBuild: [][]string{{"compile"}, {"all"}},
 		},
 	}


### PR DESCRIPTION
Removes usage of the deprecated ioutil package as described [here](https://golang.org/doc/go1.16#ioutil)

[_Created by Sourcegraph batch change `rslade/deprecate-ioutil`._](https://k8s.sgdev.org/users/rslade/batch-changes/deprecate-ioutil)